### PR TITLE
Missing dependencies in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.egg-info
 *.swp
 *.swo
+.eggs
 build
 dist
 docs

--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,7 @@ setup(
     url='https://github.com/google/jws',
     packages=find_packages(exclude=['tests']),
     test_suite='tests',
+    install_requires=[
+        'cryptography'
+    ]
 )


### PR DESCRIPTION
When running `python setup.py test` on a fresh virtual environment:

```
ImportError: Failed to import test module: jws_test
Traceback (most recent call last):
  File "/usr/lib64/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/julien/tmp/jws2/tests/jws_test.py", line 21, in <module>
    from jws import jwsutil
  File "/home/julien/tmp/jws2/jws/__init__.py", line 15, in <module>
    from .jws import (JwsPublicKeySign, JwsPublicKeyVerify, JwsMacVerify,
  File "/home/julien/tmp/jws2/jws/jws.py", line 31, in <module>
    from cryptography import exceptions
ModuleNotFoundError: No module named 'cryptography'
```

This dependency was not listed in `setup.py`.